### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "through": "~2.3.4",
         "gulp-util": "~2.2.14",
-        "autopolyfiller": "1.1.x"
+        "autopolyfiller": "1.4.x"
     },
     "devDependencies": {
         "mocha": "*",


### PR DESCRIPTION
it looks like autopolyfiller 1.1.x stopped working, due to the retiring of the original polyfill github project. referencing your newer 1.4.x polyfill seems to work, for us anyways.
